### PR TITLE
Add rotary encoder to hardware diagram

### DIFF
--- a/diagram.json
+++ b/diagram.json
@@ -5,7 +5,8 @@
   "parts": [
     { "id": "esp", "type": "chip", "model": "ESP32-S3" },
     { "id": "oled", "type": "display", "model": "SSD1306" },
-    { "id": "sd", "type": "storage", "model": "SD" }
+    { "id": "sd", "type": "storage", "model": "SD" },
+    { "id": "encoder", "type": "wokwi-ky-040" }
   ],
   "connections": [
     [ "esp:3V3", "oled:VCC" ],
@@ -18,6 +19,12 @@
     [ "esp:GPIO12", "sd:MISO" ],
     [ "esp:GPIO11", "sd:MOSI" ],
     [ "esp:GPIO13", "sd:SCK" ],
-    [ "esp:GPIO10", "sd:CS" ]
+    [ "esp:GPIO10", "sd:CS" ],
+
+    [ "esp:3V3", "encoder:VCC" ],
+    [ "esp:GND", "encoder:GND" ],
+    [ "esp:GPIO4", "encoder:CLK" ],
+    [ "esp:GPIO5", "encoder:DT" ],
+    [ "esp:GPIO6", "encoder:SW" ]
   ]
 }


### PR DESCRIPTION
## Summary
- add KY-040 rotary encoder to diagram
- wire ESP32-S3, OLED display, SD card, and rotary encoder for simulation

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: no matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c219a9b14c83289e267cd72f8eaeb5