### PR TITLE
Fix Wokwi wiring for ESP32-S3 project

### DIFF
--- a/diagram.json
+++ b/diagram.json
@@ -3,9 +3,10 @@
   "author": "Hemingway Editor",
   "editor": "wokwi",
   "parts": [
-    { "id": "esp", "type": "chip", "model": "ESP32-S3" },
-    { "id": "oled", "type": "display", "model": "SSD1306" },
-    { "id": "sd", "type": "storage", "model": "SD" }
+    { "type": "wokwi-esp32-s3-devkitc-1", "id": "esp" },
+    { "type": "wokwi-ssd1306", "id": "oled" },
+    { "type": "wokwi-microsd-card", "id": "sd" },
+    { "type": "wokwi-ky-040", "id": "encoder" }
   ],
   "connections": [
     [ "esp:3V3", "oled:VCC" ],
@@ -18,6 +19,12 @@
     [ "esp:GPIO12", "sd:MISO" ],
     [ "esp:GPIO11", "sd:MOSI" ],
     [ "esp:GPIO13", "sd:SCK" ],
-    [ "esp:GPIO10", "sd:CS" ]
+    [ "esp:GPIO10", "sd:CS" ],
+
+    [ "esp:3V3", "encoder:VCC" ],
+    [ "esp:GND", "encoder:GND" ],
+    [ "esp:GPIO4", "encoder:CLK" ],
+    [ "esp:GPIO5", "encoder:DT" ],
+    [ "esp:GPIO6", "encoder:SW" ]
   ]
 }

--- a/wokwi-project.json
+++ b/wokwi-project.json
@@ -1,0 +1,4 @@
+{
+  "name": "Hemingway Editor",
+  "board": "esp32-s3-devkitc-1"
+}


### PR DESCRIPTION
## Summary
- define Wokwi parts for ESP32-S3, SSD1306 display, SD card, and rotary encoder
- add Wokwi project file specifying esp32-s3-devkitc-1 board

## Testing
- `idf.py build` *(fails: command not found)*
- `pip install esp-idf` *(fails: No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_68c219a9b14c83289e267cd72f8eaeb5